### PR TITLE
fix(docker): add workaround to preinstall js-yaml types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ RUN apt-get update && apt-get install -y git
 WORKDIR /usr/src/app
 COPY package.json yarn.lock tsconfig.json ./
 RUN yarn install --production
+# Workaround for error TS7016: Could not find a declaration file for module 'js-yaml'
+RUN yarn add --dev @types/js-yaml
 RUN yarn cache clean
 ENV NODE_ENV="production"
 COPY . .


### PR DESCRIPTION
observed error in https://github.com/mdolinin/gha-conductor/actions/runs/8499523542/job/23280435872#step:5:547
```
 > [8/8] RUN yarn build:
0.312 yarn run v1.22.19
0.334 $ tsc
3.035 src/gha_loader.ts(6,20): error TS7016: Could not find a declaration file for module 'js-yaml'. '/usr/src/app/node_modules/js-yaml/index.js' implicitly has an 'any' type.
3.035   Try `npm i --save-dev @types/js-yaml` if it exists or add a new declaration (.d.ts) file containing `declare module 'js-yaml';`
3.066 error Command failed with exit code 2.
3.066 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
------
Dockerfile:9
--------------------
   7 |     ENV NODE_ENV="production"
   8 |     COPY . .
   9 | >>> RUN yarn build
  10 |     CMD [ "yarn", "bot:start" ]
  11 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn build" did not complete successfully: exit code: 2
```