### PR TITLE
fix(hooks): persist workflow run as soon as it dispatched

### DIFF
--- a/src/gha_checks.ts
+++ b/src/gha_checks.ts
@@ -47,32 +47,6 @@ export class GhaChecks {
         this.log = log;
     }
 
-    async createNewRun(triggeredWorkflow: TriggeredWorkflow, pull_request: {
-        number: number
-    }, hookType: "onBranchMerge" | "onPullRequest" | "onPullRequestClose" | "onSlashCommand", merge_commit_sha: string) {
-        const {headSha, checkName} = this.parseHeadShaFromJobName(triggeredWorkflow.name);
-        if (headSha) {
-            let workflowRun = {
-                name: checkName,
-                head_sha: headSha,
-                merge_commit_sha: merge_commit_sha,
-                pipeline_run_name: triggeredWorkflow.name,
-                workflow_run_inputs: triggeredWorkflow.inputs,
-                pr_number: pull_request.number,
-                hook: hookType,
-            }
-            if (triggeredWorkflow.error) {
-                workflowRun = Object.assign(workflowRun, {
-                    status: "completed",
-                    conclusion: "failure"
-                });
-            }
-            await gha_workflow_runs(db).insert(workflowRun);
-        } else {
-            this.log.error("Failed to parse head sha from triggeredWorkflow name " + triggeredWorkflow);
-        }
-    }
-
     private hookToCheckName(hookType: "onBranchMerge" | "onPullRequest" | "onPullRequestClose" | "onSlashCommand") {
         switch (hookType) {
             case "onPullRequest":

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,6 @@ export = (app: Probot, {getRouter}: ApplicationFunctionOptions) => {
             const workflowFileExtension = await getValueFromConfig(context, repo_full_name, "workflow_file_extension");
             const triggeredWorkflows = await hooks.runWorkflow(context.octokit, context.payload.pull_request, context.payload.action, triggeredHooks, merge_commit_sha, undefined, workflowFileExtension);
             for (const triggeredWorkflow of triggeredWorkflows) {
-                await checks.createNewRun(triggeredWorkflow, context.payload.pull_request, hookType, merge_commit_sha);
                 if (triggeredWorkflow.error) {
                     await checks.createWorkflowRunCheckErrored(context.octokit, context.payload.pull_request, hookType, merge_commit_sha, triggeredWorkflow);
                 }
@@ -427,7 +426,6 @@ export = (app: Probot, {getRouter}: ApplicationFunctionOptions) => {
             const workflowFileExtension = await getValueFromConfig(context, repo_full_name, "workflow_file_extension");
             const triggeredWorkflows = await hooks.runWorkflow(context.octokit, pr, context.payload.action, triggeredHooks, merge_commit_sha, commandTokens, workflowFileExtension);
             for (const triggeredWorkflow of triggeredWorkflows) {
-                await checks.createNewRun(triggeredWorkflow, pr, hookType, merge_commit_sha);
                 if (triggeredWorkflow.error) {
                     await checks.createWorkflowRunCheckErrored(context.octokit, pr, hookType, merge_commit_sha, triggeredWorkflow);
                 }

--- a/test/gha_checks.test.ts
+++ b/test/gha_checks.test.ts
@@ -5,7 +5,7 @@ import workflowJobInProgressPayload from "./fixtures/workflow_job.in_progress.js
 import workflowJobCompletedPayload from "./fixtures/workflow_job.completed.json";
 import checkRunRequestedActionPayload from "./fixtures/check_run.requested_action.json";
 import checkRunReRequestedPayload from "./fixtures/check_run.rerequested.json";
-import {PullRequest} from "@octokit/webhooks-types";
+
 import {TriggeredWorkflow} from "../src/hooks";
 import {Logger} from "probot";
 
@@ -73,70 +73,6 @@ describe('gha_checks', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-    });
-
-    it('store new run into db, including errors', async () => {
-        const pipeline = {name: 'gha-checks-1234567890', inputs: {}, error: "ref not exist"};
-        const pullRequestOpened: PullRequest & {
-            state: "open";
-            closed_at: null;
-            merged_at: null;
-            merged: boolean;
-            merged_by: null;
-        } = {
-            ...pullRequestOpenedPayload.pull_request,
-            author_association: "OWNER",
-            state: "open",
-            user: {
-                ...pullRequestOpenedPayload.pull_request.user,
-                type: "User",
-            },
-            base: {
-                ...pullRequestOpenedPayload.pull_request.base,
-                user: {
-                    ...pullRequestOpenedPayload.pull_request.base.user,
-                    type: "User",
-                },
-                repo: {
-                    ...pullRequestOpenedPayload.pull_request.base.repo,
-                    custom_properties: {},
-                    visibility: "private",
-                    owner: {
-                        ...pullRequestOpenedPayload.pull_request.base.repo.owner,
-                        type: "User",
-                    },
-                }
-            },
-            head: {
-                ...pullRequestOpenedPayload.pull_request.head,
-                user: {
-                    ...pullRequestOpenedPayload.pull_request.head.user,
-                    type: "User",
-                },
-                repo: {
-                    ...pullRequestOpenedPayload.pull_request.head.repo,
-                    custom_properties: {},
-                    visibility: "private",
-                    owner: {
-                        ...pullRequestOpenedPayload.pull_request.head.repo.owner,
-                        type: "User",
-                    },
-                }
-            }
-        };
-        const merge_commit_sha = '1234567890';
-        await checks.createNewRun(pipeline, pullRequestOpened, 'onPullRequest', merge_commit_sha);
-        expect(insertMock).toHaveBeenCalledWith({
-            name: 'gha-checks',
-            head_sha: merge_commit_sha,
-            merge_commit_sha: merge_commit_sha,
-            pipeline_run_name: pipeline.name,
-            workflow_run_inputs: {},
-            pr_number: pullRequestOpened.number,
-            hook: 'onPullRequest',
-            status: 'completed',
-            conclusion: 'failure',
-        });
     });
 
     it('should create check if workflow run got error on attempt to trigger', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -75,12 +75,6 @@ let runWorkflowMock = jest
         return Promise.resolve([]);
     });
 
-const createNewRunMock = jest
-    .spyOn(GhaChecks.prototype, 'createNewRun')
-    .mockImplementation(() => {
-        return Promise.resolve();
-    });
-
 const createWorkflowRunCheckErroredMock = jest
     .spyOn(GhaChecks.prototype, 'createWorkflowRunCheckErrored')
     .mockImplementation(() => {
@@ -370,7 +364,6 @@ describe("gha-conductor app", () => {
         expect(loadGhaHooksMock).toHaveBeenCalledTimes(0);
         expect(filterTriggeredHooksMock).toHaveBeenCalledTimes(0);
         expect(runWorkflowMock).toHaveBeenCalledTimes(0);
-        expect(createNewRunMock).toHaveBeenCalledTimes(0);
         expect(createWorkflowRunCheckErroredMock).toHaveBeenCalledTimes(0);
         expect(createPRCheckNoPipelinesTriggeredMock).toHaveBeenCalledTimes(0);
         expect(createPRCheckForAllErroredPipelinesMock).toHaveBeenCalledTimes(0);
@@ -417,7 +410,6 @@ describe("gha-conductor app", () => {
         expect(loadGhaHooksMock).toHaveBeenCalledTimes(1);
         expect(filterTriggeredHooksMock).toHaveBeenCalledTimes(1);
         expect(runWorkflowMock).toHaveBeenCalledTimes(1);
-        expect(createNewRunMock).toHaveBeenCalledTimes(1);
         expect(createWorkflowRunCheckErroredMock).toHaveBeenCalledTimes(1);
         expect(createPRCheckNoPipelinesTriggeredMock).toHaveBeenCalledTimes(0);
         expect(createPRCheckForAllErroredPipelinesMock).toHaveBeenCalledTimes(1);
@@ -457,7 +449,6 @@ describe("gha-conductor app", () => {
         expect(loadGhaHooksMock).toHaveBeenCalledTimes(1);
         expect(filterTriggeredHooksMock).toHaveBeenCalledTimes(1);
         expect(runWorkflowMock).toHaveBeenCalledTimes(1);
-        expect(createNewRunMock).toHaveBeenCalledTimes(0);
         expect(createWorkflowRunCheckErroredMock).toHaveBeenCalledTimes(0);
         expect(createPRCheckNoPipelinesTriggeredMock).toHaveBeenCalledTimes(1);
         expect(createPRCheckForAllErroredPipelinesMock).toHaveBeenCalledTimes(0);
@@ -500,7 +491,6 @@ describe("gha-conductor app", () => {
         expect(loadGhaHooksMock).toHaveBeenCalledTimes(1);
         expect(filterTriggeredHooksMock).toHaveBeenCalledTimes(1);
         expect(runWorkflowMock).toHaveBeenCalledTimes(1);
-        expect(createNewRunMock).toHaveBeenCalledTimes(1);
         expect(createWorkflowRunCheckErroredMock).toHaveBeenCalledTimes(0);
         expect(createPRCheckNoPipelinesTriggeredMock).toHaveBeenCalledTimes(0);
         expect(createPRCheckForAllErroredPipelinesMock).toHaveBeenCalledTimes(0);
@@ -644,7 +634,6 @@ describe("gha-conductor app", () => {
         expect(loadGhaHooksMock).toHaveBeenCalledTimes(1);
         expect(filterTriggeredHooksMock).toHaveBeenCalledTimes(1);
         expect(runWorkflowMock).toHaveBeenCalledTimes(1);
-        expect(createNewRunMock).toHaveBeenCalledTimes(1);
         expect(createWorkflowRunCheckErroredMock).toHaveBeenCalledTimes(0);
         expect(createPRCheckNoPipelinesTriggeredMock).toHaveBeenCalledTimes(0);
         expect(createPRCheckForAllErroredPipelinesMock).toHaveBeenCalledTimes(0);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,6 +70,6 @@
     "skipLibCheck": true
   },
   "hooks": [ "copy-files" ],
-  "include": ["src/**/*", "src/__generated__/schema.json"],
+  "include": ["src/**/*", "src/__generated__/schema.json", "src/schemas/gha_yaml_schema.json"],
   "compileOnSave": false
 }


### PR DESCRIPTION
* in case we have long list of workflows to trigger we need to persist information about dispatched workflow as soon as possible
* some of workflows will start execution and sending events even before we complete iterate over long list of workflows that should be triggered