### PR TITLE
fix: stop truncating branch names containing a slash in push handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export default (app: Probot, {getRouter}: ApplicationFunctionOptions) => {
         // if push was delete branch
         if (context.payload.deleted) {
             const ref = context.payload.ref;
-            const branchName = ref.split("/").pop();
+            const branchName = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : undefined;
             if (ref.startsWith("refs/heads/") && branchName) {
                 await ghaLoader.deleteAllGhaHooksForBranch(repoFullName, branchName);
                 app.log.info(`Delete all gha hooks for branch ${branchName} in repo ${repoFullName} completed`);
@@ -82,7 +82,7 @@ export default (app: Probot, {getRouter}: ApplicationFunctionOptions) => {
             }
         }
         const ref = context.payload.ref;
-        const branchName = ref.split("/").pop();
+        const branchName = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : undefined;
         let reloadConfig = false;
         if (configFileChanged) {
             if (ref.startsWith("refs/heads/") && branchName) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -208,6 +208,17 @@ describe("gha-conductor app", () => {
     it("delete all related gha hooks, when branch is deleted", async () => {
         await probot.receive({name: "push", payload: deleteBranchPayload});
         expect(deleteAllGhaHooksForBranchMock).toHaveBeenCalledTimes(1);
+        expect(deleteAllGhaHooksForBranchMock).toHaveBeenCalledWith("mdolinin/mono-repo-example", "mdolinin-patch-4");
+    });
+
+    it("delete all related gha hooks, when branch with slash in name is deleted", async () => {
+        const deleteSlashBranchPayload = {
+            ...deleteBranchPayload,
+            ref: "refs/heads/feature/x",
+        }
+        await probot.receive({name: "push", payload: deleteSlashBranchPayload});
+        expect(deleteAllGhaHooksForBranchMock).toHaveBeenCalledTimes(1);
+        expect(deleteAllGhaHooksForBranchMock).toHaveBeenCalledWith("mdolinin/mono-repo-example", "feature/x");
     });
 
     it("when pushed changes with gha-conductor-config.yaml and branch is base, reload config from file", async () => {
@@ -254,6 +265,36 @@ describe("gha-conductor app", () => {
             ".gha.yaml",
             ghaYamlChangedAndHavePROpenedPayload.commits,
             ghaYamlChangedAndHavePROpenedPayload.after
+        );
+        expect(mock.pendingMocks()).toStrictEqual([]);
+    });
+
+    it("when pushed changes with .gha.yaml and branch name contains a slash, load incrementally from commits using the full branch name", async () => {
+        const mock = nock("https://api.github.com")
+            .post("/app/installations/44167724/access_tokens")
+            .reply(200, {
+                token: "test",
+                permissions: {
+                    pull_requests: "write",
+                },
+            })
+            .get("/repos/mdolinin/mono-repo-example/contents/.github%2Fgha-conductor-config.yaml")
+            .reply(200, "gha_hooks_file: .gha.yaml")
+        const ghaYamlChangedOnSlashBranchPayload = {
+            ...pushGhaYamlChangedPayload,
+            ref: "refs/heads/feature/x",
+        }
+        await probot.receive({name: "push", payload: ghaYamlChangedOnSlashBranchPayload});
+        expect(countHooksForBranchMock).toHaveBeenCalledTimes(1);
+        expect(countHooksForBranchMock).toHaveBeenCalledWith("mdolinin/mono-repo-example", "feature/x");
+        expect(loadGhaHooksFromCommitsMock).toHaveBeenCalledTimes(1);
+        expect(loadGhaHooksFromCommitsMock).toHaveBeenCalledWith(
+            expect.anything(),
+            "mdolinin/mono-repo-example",
+            "feature/x",
+            ".gha.yaml",
+            ghaYamlChangedOnSlashBranchPayload.commits,
+            ghaYamlChangedOnSlashBranchPayload.after
         );
         expect(mock.pendingMocks()).toStrictEqual([]);
     });


### PR DESCRIPTION
## Problem

The `push` event handler derived the branch name with `ref.split("/").pop()`, which only keeps the last path segment. For any branch name containing a slash — `chore/x`, `feature/x`, `release/x`, `hotfix/x` — an extremely common naming convention — this silently truncated the name (`refs/heads/chore/x` → `x` instead of `chore/x`).

Every downstream lookup then operated on the wrong name: `countHooksForBranch`/`loadGhaHooksFromCommits` (and `deleteAllGhaHooksForBranch` on branch deletion) queried the DB for the truncated name, which is never what hooks are actually cached under (the `pull_request` handlers correctly use `context.payload.pull_request.base.ref`, unaffected by this bug). The push handler always concluded "branch does not exist in db... No hooks will be loaded from push" and silently skipped the incremental hook-cache sync — for every slash-named branch, unconditionally, not as a rare edge case.

Found while working the handoff doc at `handoff-issues/02-branch-name-truncation-in-push-handler.md` (from #531) — reproduced live against a real branch named `chore/e2e-lock-race-test`, where this exact truncation showed up in the app's own logs.

## Fix

Strip the fixed `refs/heads/` prefix instead of splitting on every `/`, at both call sites (the delete-branch handler and the main push-processing handler):

```diff
- const branchName = ref.split("/").pop();
+ const branchName = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : undefined;
```

## Testing

- New test: pushing to `refs/heads/feature/x` now correctly calls `countHooksForBranch`/`loadGhaHooksFromCommits` with the full `"feature/x"` string.
- New test: deleting `refs/heads/feature/x` calls `deleteAllGhaHooksForBranch` with `"feature/x"`.
- Tightened an existing delete-branch test to assert the exact branch name argument (previously only checked call count).
- Full suite passes (78/78), `tsc --noEmit` clean, build clean.
- Rebased onto current `main` (post-#531/v1.22.3) with no conflicts.

## Possible connection to a real incident

This may also explain part of why a real production hotfix branch (`chore/client-web-v2026.28.0-hotfix` — same "prefix/name" shape) failed to sync via the push-driven path independent of whatever else happened to that specific webhook delivery. Worth a look if that incident gets revisited.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>