### PR TITLE
fix: redact installation access token from debug/error logs

### DIFF
--- a/src/gha_loader.ts
+++ b/src/gha_loader.ts
@@ -82,10 +82,11 @@ export class GhaLoader {
             fs.mkdirSync(target, {recursive: true});
             // clone repo
             let remote = `https://x-access-token:${token}@github.com/${full_name}.git`;
-            this.log.debug(`Repo path is ${remote}`);
+            const redactedRemote = `https://x-access-token:***@github.com/${full_name}.git`;
+            this.log.debug(`Repo path is ${redactedRemote}`);
             const cloneResp = await this.git.clone(remote, target);
             if (cloneResp !== "") {
-                this.log.error(`Error cloning ${remote} repo ${cloneResp}`);
+                this.log.error(`Error cloning ${redactedRemote} repo ${cloneResp}`);
                 return;
             }
             // then set the working directory of the root instance - you want all future

--- a/test/gha_loader.test.ts
+++ b/test/gha_loader.test.ts
@@ -216,20 +216,44 @@ describe('gha loader', () => {
         const octokit = {
             auth: vi.fn().mockImplementation(() => {
                 return {
-                    token: "token"
+                    token: "sekret-installation-token"
                 }
             }),
         };
         // @ts-ignore
         await ghaLoader.loadAllGhaHooksFromRepo(octokit, "repo_full_name", "branch", ".gha.yaml");
         expect(octokit.auth).toHaveBeenCalledWith({type: "installation"});
-        expect(cloneMock).toHaveBeenCalledWith("https://x-access-token:token@github.com/repo_full_name.git", expect.stringMatching(RegExp('.*repo_full_name')));
+        expect(cloneMock).toHaveBeenCalledWith("https://x-access-token:sekret-installation-token@github.com/repo_full_name.git", expect.stringMatching(RegExp('.*repo_full_name')));
         expect(cwdMock).toHaveBeenCalledWith({path: expect.stringMatching(RegExp('.*repo_full_name')), root: true});
         expect(checkoutBranchMock).toHaveBeenCalledWith("branch", "origin/branch");
         expect(globMock).toHaveBeenCalled();
         expect(readFileSyncMockCounter).toBe(2);
         expect(deleteMock).toHaveBeenCalledTimes(1)
         expect(insertMock).toHaveBeenCalledTimes(10);
+        for (const mockFn of [logMock.debug, logMock.info, logMock.warn, logMock.error]) {
+            for (const call of mockFn.mock.calls) {
+                expect(call.join(' ')).not.toContain("sekret-installation-token");
+            }
+        }
+    });
+
+    it('should not leak the installation token in logs, when cloning the repo fails', async () => {
+        const octokit = {
+            auth: vi.fn().mockImplementation(() => {
+                return {
+                    token: "sekret-clone-failure-token"
+                }
+            }),
+        };
+        cloneMock.mockReturnValueOnce(Promise.resolve("fatal: could not clone"));
+        // @ts-ignore
+        await ghaLoader.loadAllGhaHooksFromRepo(octokit, "repo_full_name", "branch", ".gha.yaml");
+        expect(logMock.error).toHaveBeenCalledWith("Error cloning https://x-access-token:***@github.com/repo_full_name.git repo fatal: could not clone");
+        for (const mockFn of [logMock.debug, logMock.info, logMock.warn, logMock.error]) {
+            for (const call of mockFn.mock.calls) {
+                expect(call.join(' ')).not.toContain("sekret-clone-failure-token");
+            }
+        }
     });
 
     it('should check yaml is valid, when gha yaml file is changed in PR', async () => {


### PR DESCRIPTION
## Problem

`loadAllGhaHooksFromRepo` builds a git remote URL embedding the short-lived GitHub App installation access token, then logs the *full URL, including the token* — both on the happy path (`this.log.debug`) and on clone failure (`this.log.error`, which the handoff doc had missed). Anywhere this app's logs land (Datadog, CloudWatch, local terminal, CI logs) ends up with a live credential.

Found via `handoff-issues/01-installation-token-leaked-in-debug-logs.md` (from #531), observed live in local end-to-end testing.

## Fix

Log a redacted form (`https://x-access-token:***@github.com/...`) at both call sites; the real remote (with the token) is still passed to `git.clone()` unchanged.

## Testing

- Extended the existing success-path test to assert no log call (`debug`/`info`/`warn`/`error`) contains the installation token.
- Added a new test for the clone-*failure* path with the same assertion (the sibling leak).
- Scoped: grepped `src/*.ts` for `x-access-token`/`token}`-style patterns — no other instances found.
- Full suite passes (77/77), `tsc --noEmit` clean, build clean.
- Rebased onto current `main` (post-#531/v1.22.3) with no conflicts.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>