### PR TITLE
fix: match dotfile hooks paths against ** file-change globs

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -90,7 +90,7 @@ export class Hooks {
                     break;
                 }
                 for (const file of files_changed) {
-                    if (!hook.file_changes_matcher.startsWith("!") && minimatch(file, hook.file_changes_matcher)) {
+                    if (!hook.file_changes_matcher.startsWith("!") && minimatch(file, hook.file_changes_matcher, {dot: true})) {
                         this.log.info(`File ${file} matches matcher ${hook.file_changes_matcher} for hook ${hook.pipeline_unique_prefix}`);
                         triggeredHooks.add(hook);
                         matched = true;

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -156,6 +156,29 @@ describe('gha hooks', () => {
         expect(findAllMock).toHaveBeenCalledTimes(1);
     });
 
+    it('find hooks to trigger, when the hooks file itself is the only file changed in the PR', async () => {
+        const hookFile = "namespaces/domain-a/projects/example-a/.gha-hooks.yaml";
+        const buildHook = {
+            repo_full_name: "repo_full_name",
+            branch: "",
+            file_changes_matcher: "namespaces/domain-a/projects/example-a/**",
+            destination_branch_matcher: null,
+            hook: "onPullRequest" as HookType,
+            hook_name: "build",
+            path_to_gha_yaml: hookFile,
+            pipeline_unique_prefix: "domain-a-example-a-build",
+            pipeline_name: "common-job",
+            pipeline_ref: undefined,
+            pipeline_params: {},
+            shared_params: {},
+            slash_command: undefined
+        };
+        const triggeredHooks = await hooks.filterTriggeredHooks(
+            "repo_full_name", "onPullRequest", [hookFile], "baseBranch",
+            {hooks: [buildHook], hookFilesModified: new Set([hookFile])});
+        expect(triggeredHooks).toEqual(new Set([buildHook]));
+    });
+
     it('find hooks to trigger, when matched files changed on slash command received', async () => {
         const hook = {
             repo_full_name: "repo_full_name",


### PR DESCRIPTION
## Problem

`Hooks.filterTriggeredHooks` calls `minimatch(file, hook.file_changes_matcher)` without `{dot: true}`. minimatch's default behavior does not match dotfiles (`.gha-hooks.yaml`, `.gha.yaml`) against `*`/`**` glob segments — a well-known minimatch/glob convention (dotfiles are hidden from globs unless explicitly opted in).

So whenever a PR's *only* changed file was the hooks file itself, none of that module's hooks could fire — not just hooks related to the actual edit, but unrelated ones too (e.g. a broad-glob `build`/`test` hook that should trigger on virtually any change under its module's path). The hooks file's own dotfile path could never satisfy a `fileChangesMatchAny` pattern like `namespaces/x/**`, even though a non-dotfile change under the same path matches fine.

Found and root-caused via `handoff-issues/03-pr-own-diff-hooks-file-change-not-triggered.md` (from #531) — the handoff doc had a suspect (missing `repoFullName`/`branch` args at a `getGhaHooks` call site) that turned out **not** to be causal; confirmed by reproducing the failure with those fields correctly populated and having it still fail. The actual cause is the `minimatch` call in `filterTriggeredHooks`.

## Fix

```diff
- if (!hook.file_changes_matcher.startsWith("!") && minimatch(file, hook.file_changes_matcher)) {
+ if (!hook.file_changes_matcher.startsWith("!") && minimatch(file, hook.file_changes_matcher, {dot: true})) {
```

## Testing

- New unit test in `test/hooks.test.ts`: a hooks file itself as the only changed file, matched against a broad `**` `onPullRequest` hook — fails on old code, passes with the fix.
- **Live end-to-end verification** against a real GitHub App + webhook flow (`mdolinin/mono-repo-legendary`): opened a PR whose *only* diff was `.gha-hooks.yaml`, matching the exact reported scenario.
  - Before this fix (same scenario, different PR, pre-fix build): **zero** hooks fired, at either PR-open or merge.
  - With this fix: the `onPullRequest` `build` hook fired and completed successfully at PR-open, and the `onBranchMerge` `release` hook fired and completed successfully on merge.
- Full suite passes (77/77), `tsc --noEmit` clean, build clean.
- Rebased onto current `main` (post-#531/v1.22.3) with no conflicts.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>