### PR TITLE
fix: isolate concurrent full-reloads of different branches in the same repo

### DIFF
--- a/src/gha_loader.ts
+++ b/src/gha_loader.ts
@@ -37,8 +37,6 @@ const validator = ajv.compile(schema);
 
 export class GhaLoader {
 
-    private git = simpleGit();
-
     log: Logger;
 
     constructor(log: Logger) {
@@ -53,6 +51,11 @@ export class GhaLoader {
      * statements and leave the cache duplicated or stamped with a sha that doesn't reflect what
      * was actually written. The lock is released automatically when the transaction commits or
      * rolls back, so callers never need to unlock explicitly.
+     *
+     * Note this only serializes calls for the *same* (repo, branch) pair. It does not protect
+     * loadAllGhaHooksFromRepo's git clone/checkout against two *different* branches of the same
+     * repo being reloaded concurrently - that's what createGit() and the per-branch clone
+     * directory below are for.
      */
     private async withBranchLock<T>(repo_full_name: string, branch: string, fn: (tx: Queryable) => Promise<T>): Promise<T | undefined> {
         try {
@@ -66,15 +69,24 @@ export class GhaLoader {
         }
     }
 
+    // Overridable in tests. A fresh instance per call is required because each call gets its own
+    // clone directory (see loadAllGhaHooksFromRepo) - a shared instance's cwd would otherwise be
+    // mutated out from under concurrent calls for different branches of the same repo.
+    private createGit() {
+        return simpleGit();
+    }
+
     async loadAllGhaHooksFromRepo(octokit: InstanceType<typeof ProbotOctokit>, full_name: string, branch: string, hooksFileName: string, tx?: Queryable): Promise<void> {
         if (!tx) {
             return this.withBranchLock(full_name, branch, (lockedTx) => this.loadAllGhaHooksFromRepo(octokit, full_name, branch, hooksFileName, lockedTx));
         }
         try {
+            const git = this.createGit();
             const {token} = await octokit.auth({type: "installation"}) as Record<string, string>;
             this.log.debug(`Repo full name is ${full_name}`);
-            // create temp dir
-            const target = path.join(process.env.TMPDIR || '/tmp/', full_name);
+            // create temp dir, scoped per-branch so concurrent full-reloads for different
+            // branches of the same repo don't clobber each other's clone
+            const target = path.join(process.env.TMPDIR || '/tmp/', full_name, branch);
             this.log.debug(`Temp dir is ${target}`);
             if (fs.existsSync(target)) {
                 fs.rmSync(target, {recursive: true, force: true});
@@ -84,20 +96,20 @@ export class GhaLoader {
             let remote = `https://x-access-token:${token}@github.com/${full_name}.git`;
             const redactedRemote = `https://x-access-token:***@github.com/${full_name}.git`;
             this.log.debug(`Repo path is ${redactedRemote}`);
-            const cloneResp = await this.git.clone(remote, target);
+            const cloneResp = await git.clone(remote, target);
             if (cloneResp !== "") {
                 this.log.error(`Error cloning ${redactedRemote} repo ${cloneResp}`);
                 return;
             }
-            // then set the working directory of the root instance - you want all future
+            // then set the working directory of this call's own instance - you want all future
             // tasks run through `git` to be from the new directory, rather than just tasks
             // chained off this task
-            await this.git.cwd({path: target, root: true});
+            await git.cwd({path: target, root: true});
             if (branch !== "master" && branch !== "main") {
-                const checkoutResp = await this.git.checkoutBranch(branch, `origin/${branch}`);
+                const checkoutResp = await git.checkoutBranch(branch, `origin/${branch}`);
                 this.log.debug("Checkout response is " + JSON.stringify(checkoutResp));
             }
-            const branchHeadSha = (await this.git.revparse("HEAD")).trim();
+            const branchHeadSha = (await git.revparse("HEAD")).trim();
             // find all hooks files in repo using glob lib
             const ghaYamlFiles = await glob(`**/${hooksFileName}`, {cwd: target});
             // parse yaml

--- a/src/gha_loader.ts
+++ b/src/gha_loader.ts
@@ -92,38 +92,48 @@ export class GhaLoader {
                 fs.rmSync(target, {recursive: true, force: true});
             }
             fs.mkdirSync(target, {recursive: true});
-            // clone repo
-            let remote = `https://x-access-token:${token}@github.com/${full_name}.git`;
-            const redactedRemote = `https://x-access-token:***@github.com/${full_name}.git`;
-            this.log.debug(`Repo path is ${redactedRemote}`);
-            const cloneResp = await git.clone(remote, target);
-            if (cloneResp !== "") {
-                this.log.error(`Error cloning ${redactedRemote} repo ${cloneResp}`);
-                return;
+            try {
+                // clone repo
+                let remote = `https://x-access-token:${token}@github.com/${full_name}.git`;
+                const redactedRemote = `https://x-access-token:***@github.com/${full_name}.git`;
+                this.log.debug(`Repo path is ${redactedRemote}`);
+                const cloneResp = await git.clone(remote, target);
+                if (cloneResp !== "") {
+                    this.log.error(`Error cloning ${redactedRemote} repo ${cloneResp}`);
+                    return;
+                }
+                // then set the working directory of this call's own instance - you want all future
+                // tasks run through `git` to be from the new directory, rather than just tasks
+                // chained off this task
+                await git.cwd({path: target, root: true});
+                if (branch !== "master" && branch !== "main") {
+                    const checkoutResp = await git.checkoutBranch(branch, `origin/${branch}`);
+                    this.log.debug("Checkout response is " + JSON.stringify(checkoutResp));
+                }
+                const branchHeadSha = (await git.revparse("HEAD")).trim();
+                // find all hooks files in repo using glob lib
+                const ghaYamlFiles = await glob(`**/${hooksFileName}`, {cwd: target});
+                // parse yaml
+                let newHooks: GhaHook[] = [];
+                for (const ghaYamlFilePath of ghaYamlFiles) {
+                    this.log.info(`Found ${hooksFileName} file ${ghaYamlFilePath}`);
+                    const ghaFileYaml = load(fs.readFileSync(path.join(target, ghaYamlFilePath), "utf8"));
+                    this.log.debug(`Parsed yaml of ${ghaYamlFilePath} is ${JSON.stringify(ghaFileYaml)}`);
+                    const hooksFromFile = this.getGhaHooks(<TheRootSchema>ghaFileYaml, ghaYamlFilePath, full_name, branch, branchHeadSha);
+                    newHooks = newHooks.concat(hooksFromFile);
+                }
+                this.log.debug(`Reinserting all ${newHooks.length} hooks`);
+                await gha_hooks(tx).delete({repo_full_name: full_name, branch: branch});
+                await Promise.all(newHooks.map(hook => gha_hooks(tx).insert(hook)));
+            } finally {
+                // The clone is single-use scratch space (a fresh git.clone() runs every time, never
+                // an incremental pull), so there's nothing to gain from leaving it on disk. Each
+                // distinct branch that ever hits this full-reload path now gets its own directory
+                // (see the per-branch isolation above) - without this, every one of those would
+                // accumulate on disk forever instead of just the single, repo-scoped leftover this
+                // code used to leave behind.
+                fs.rmSync(target, {recursive: true, force: true});
             }
-            // then set the working directory of this call's own instance - you want all future
-            // tasks run through `git` to be from the new directory, rather than just tasks
-            // chained off this task
-            await git.cwd({path: target, root: true});
-            if (branch !== "master" && branch !== "main") {
-                const checkoutResp = await git.checkoutBranch(branch, `origin/${branch}`);
-                this.log.debug("Checkout response is " + JSON.stringify(checkoutResp));
-            }
-            const branchHeadSha = (await git.revparse("HEAD")).trim();
-            // find all hooks files in repo using glob lib
-            const ghaYamlFiles = await glob(`**/${hooksFileName}`, {cwd: target});
-            // parse yaml
-            let newHooks: GhaHook[] = [];
-            for (const ghaYamlFilePath of ghaYamlFiles) {
-                this.log.info(`Found ${hooksFileName} file ${ghaYamlFilePath}`);
-                const ghaFileYaml = load(fs.readFileSync(path.join(target, ghaYamlFilePath), "utf8"));
-                this.log.debug(`Parsed yaml of ${ghaYamlFilePath} is ${JSON.stringify(ghaFileYaml)}`);
-                const hooksFromFile = this.getGhaHooks(<TheRootSchema>ghaFileYaml, ghaYamlFilePath, full_name, branch, branchHeadSha);
-                newHooks = newHooks.concat(hooksFromFile);
-            }
-            this.log.debug(`Reinserting all ${newHooks.length} hooks`);
-            await gha_hooks(tx).delete({repo_full_name: full_name, branch: branch});
-            await Promise.all(newHooks.map(hook => gha_hooks(tx).insert(hook)));
         } catch (e) {
             this.log.error(e, `Error loading hooks for repo ${full_name} branch ${branch}`);
         }

--- a/test/gha_loader.test.ts
+++ b/test/gha_loader.test.ts
@@ -257,6 +257,38 @@ describe('gha loader', () => {
         }
     });
 
+    it('should clean up the clone directory after successfully loading hooks, so it does not accumulate on disk across every branch ever full-reloaded', async () => {
+        const octokit = {
+            auth: vi.fn().mockImplementation(() => {
+                return {token: "token"}
+            }),
+        };
+        // @ts-ignore
+        await ghaLoader.loadAllGhaHooksFromRepo(octokit, "repo_full_name_cleanup", "cleanup-branch", ".gha.yaml");
+        expect(fs.rmSync).toHaveBeenCalledWith(
+            expect.stringMatching(RegExp('.*repo_full_name_cleanup.*cleanup-branch')),
+            {recursive: true, force: true}
+        );
+    });
+
+    it('should clean up the clone directory, even when an error is thrown while parsing hooks', async () => {
+        const octokit = {
+            auth: vi.fn().mockImplementation(() => {
+                return {token: "token"}
+            }),
+        };
+        globMock.mockImplementationOnce(() => {
+            throw new Error("glob blew up");
+        });
+        // @ts-ignore
+        await ghaLoader.loadAllGhaHooksFromRepo(octokit, "repo_full_name_cleanup_error", "branch", ".gha.yaml");
+        expect(fs.rmSync).toHaveBeenCalledWith(
+            expect.stringMatching(RegExp('.*repo_full_name_cleanup_error.*branch')),
+            {recursive: true, force: true}
+        );
+        expect(logMock.error).toHaveBeenCalled();
+    });
+
     it('should check yaml is valid, when gha yaml file is changed in PR', async () => {
         const ghaYamlNotValid = `
         moduleName: 
@@ -895,7 +927,9 @@ describe('gha loader', () => {
         // the two calls must not have shared (or clobbered) a clone directory
         const targets = instances.map(instance => instance.target);
         expect(new Set(targets).size).toBe(2);
-        expect(new Set(rmSyncCalls).size).toBe(rmSyncCalls.length);
+        // rmSync fires twice per call now (defensive clear before clone, cleanup after use) - what
+        // matters is that only the two branch-scoped paths were ever touched, never a shared one
+        expect(new Set(rmSyncCalls)).toEqual(new Set(targets));
     });
 
 });

--- a/test/gha_loader.test.ts
+++ b/test/gha_loader.test.ts
@@ -1,6 +1,7 @@
 import {vi, describe, beforeEach, afterEach, expect, it} from "vitest";
 import {GhaLoader} from "../src/gha_loader.js";
 import {Logger} from "probot";
+import * as fs from "fs";
 
 const cloneMock = vi.fn().mockReturnValue(Promise.resolve(""));
 const cwdMock = vi.fn();
@@ -199,12 +200,12 @@ describe('gha loader', () => {
 
     beforeEach(() => {
         // @ts-ignore
-        ghaLoader.git = {
+        ghaLoader.createGit = () => ({
             clone: cloneMock,
             cwd: cwdMock,
             checkoutBranch: checkoutBranchMock,
             revparse: revparseMock
-        }
+        });
     });
 
     afterEach(() => {
@@ -843,6 +844,58 @@ describe('gha loader', () => {
     it('should delete all hooks from db, when branch is deleted', async () => {
         await ghaLoader.deleteAllGhaHooksForBranch("repo_full_name3", "branch3");
         expect(deleteMock).toHaveBeenCalledWith({repo_full_name: "repo_full_name3", branch: "branch3"});
+    });
+
+    it('should not corrupt each other\'s clone/checkout state, when two full-reloads for different branches of the same repo run concurrently', async () => {
+        // Each call must get its own git instance and its own clone directory, keyed by branch,
+        // so that call A's checkoutBranch never runs against a cwd that call B most recently set.
+        const instances: { target: string | undefined, branch: string | undefined }[] = [];
+        // @ts-ignore
+        ghaLoader.createGit = () => {
+            const instance: { target: string | undefined, branch: string | undefined } = {target: undefined, branch: undefined};
+            instances.push(instance);
+            return {
+                clone: vi.fn().mockImplementation(async () => {
+                    // yield so the other concurrent call's clone/cwd/checkout can interleave
+                    await new Promise(resolve => setTimeout(resolve, 0));
+                    return "";
+                }),
+                cwd: vi.fn().mockImplementation(async ({path: cwdPath}: { path: string }) => {
+                    instance.target = cwdPath;
+                    await new Promise(resolve => setTimeout(resolve, 0));
+                }),
+                checkoutBranch: vi.fn().mockImplementation(async (branch: string) => {
+                    instance.branch = branch;
+                })
+            };
+        };
+        const rmSyncCalls: string[] = [];
+        // @ts-ignore
+        vi.mocked(fs.rmSync).mockImplementation((target: string) => {
+            rmSyncCalls.push(target);
+        });
+
+        const octokit = {
+            auth: vi.fn().mockImplementation(() => {
+                return {token: "token"};
+            }),
+        };
+        await Promise.all([
+            // @ts-ignore
+            ghaLoader.loadAllGhaHooksFromRepo(octokit, "shared_repo", "branch-x", ".gha.yaml"),
+            // @ts-ignore
+            ghaLoader.loadAllGhaHooksFromRepo(octokit, "shared_repo", "branch-y", ".gha.yaml")
+        ]);
+
+        expect(instances).toHaveLength(2);
+        // each call's own git instance must have checked out its own branch inside its own target dir
+        for (const instance of instances) {
+            expect(instance.target).toEqual(expect.stringContaining(instance.branch as string));
+        }
+        // the two calls must not have shared (or clobbered) a clone directory
+        const targets = instances.map(instance => instance.target);
+        expect(new Set(targets).size).toBe(2);
+        expect(new Set(rmSyncCalls).size).toBe(rmSyncCalls.length);
     });
 
 });


### PR DESCRIPTION
## Problem

`loadAllGhaHooksFromRepo` used a single class-level `this.git = simpleGit()` instance shared across every call, and cloned into a temp directory keyed only on the repo's `full_name` — not the branch. Two full-reload calls for *different* branches of the *same* repo running concurrently (e.g. two PRs opened around the same time against two brand-new branches) could:
- delete each other's clone directory mid-checkout (`rmSync`/`mkdirSync` racing on the same path), or
- since `simple-git` tracks `cwd` on the instance itself, have one call's `checkoutBranch()` run against whatever directory the *other* call most recently `cwd()`'d the shared instance into — silently loading the wrong branch's hook definitions under the wrong branch name.

This predates the per-`(repo, branch)` advisory lock added in #531 — that lock only serializes two events for the *same* branch, so it doesn't cover this case and isn't a substitute for it (noted directly in the updated docstring).

Found via `handoff-issues/04-concurrent-full-reload-shared-git-clone-race.md` (from #531) — a code-inspection finding, not reproduced against a live race (reliably triggering it via real GitHub webhooks would need two brand-new branches hitting the full-reload path at nearly the same instant; the mocked concurrency test below reproduces the exact interleaving deterministically instead).

## Fix

Direction 2 from the handoff doc (branch-scoped isolation, preserving concurrency across branches):
- Replaced the shared `this.git` with a `createGit()` factory returning a fresh `simple-git` instance per call.
- Scoped the clone directory to `TMPDIR/<repo>/<branch>` instead of just `TMPDIR/<repo>`.

Each concurrent call now has fully independent state — no shared mutable `cwd`, no shared directory — so two branches of a busy repo can be reloaded in parallel without corrupting each other.

## Testing

- New regression test: runs two concurrent `loadAllGhaHooksFromRepo` calls for the same repo but different branches, with mocked `clone`/`cwd`/`checkoutBranch` calls that yield via `setTimeout` to force interleaving. Asserts each call's git instance ended up checked out against its own branch-scoped directory, with no shared/clobbered target.
- Verified the test is meaningful: reverting just the directory-scoping (keeping the `createGit` API) makes the new test fail as expected, catching the exact race.
- Full suite passes (including the merge with #531's advisory-lock changes to this same function, resolved by hand), `tsc --noEmit` clean, build clean.
- Rebased onto current `main` (post-#531/v1.22.3) — required manual conflict resolution since both changes touch `loadAllGhaHooksFromRepo`; kept both the `tx`/lock-acquisition wrapper from #531 and the per-call `git`/directory isolation from this PR, they're complementary (different, non-overlapping race conditions).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>